### PR TITLE
Replace MomentJS to Date Fns

### DIFF
--- a/src/components/DatePicker/DatePicker.jsx
+++ b/src/components/DatePicker/DatePicker.jsx
@@ -1,0 +1,7 @@
+import dateFnsGenerateConfig from 'rc-picker/lib/generate/dateFns';
+import generatePicker from 'antd/es/date-picker/generatePicker';
+import 'antd/es/date-picker/style/index';
+
+const DatePicker = generatePicker(dateFnsGenerateConfig);
+
+export default DatePicker;

--- a/src/components/DatePicker/index.js
+++ b/src/components/DatePicker/index.js
@@ -1,0 +1,1 @@
+export { default } from './DatePicker';


### PR DESCRIPTION
Add DatePicker component to replace MomentJS to Date Fns.

Now we need to import DatePicker from the new Component.

Issue #16 